### PR TITLE
extend to all content entity

### DIFF
--- a/config/install/twig_generator.settings.yml
+++ b/config/install/twig_generator.settings.yml
@@ -1,8 +1,17 @@
-type_to_tpl:
-  node: core/modules/node/templates/node.html.twig
-  block_content: core/modules/block/templates/block.html.twig
-  paragraph: modules/contrib/paragraphs/templates/paragraph.html.twig
-entity_type_ids:
-  - node
-  - block_content
-  - paragraph
+general:
+  add_comment: 1
+  replace_content: 1
+  view_modes: 1
+  excluded_fields: field_metatags
+block_content:
+  status: 1
+  block_content:
+    origin_tpl: core/modules/block/templates/block.html.twig
+    desti_tpl: modules/templates/block_content
+    bundles:
+      basic: basic
+node:
+  status: 1
+  node:
+    bundles:
+      article: article


### PR DESCRIPTION
J'ai étendu le concept à toutes les entité de contenu du site. De même la configuration enregistre maintenant les modifs de l'utilisateur.

Pour moi, il reste 2 points à améliorer/rajouter :
- Ajouter la possibilité de générer un TPL avec les uniquement les commentaires si ces derniers sont selectionnés mais qu'aucun tpl n'existe
- Ajouter un bouton pour "retourner à la conf d'origine" ( dans le cas où un contributeur perdrait le chemin d'un TPL)